### PR TITLE
Add two new repos

### DIFF
--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -120,5 +120,26 @@ orgs.newOrg('eclipse-kuksa') {
         },
       ],
     },
+    orgs.newRepo('kuksa-common') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('kuksa-python-sdk') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
+    orgs.newRepo('kuksa-android-companion') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      web_commit_signoff_required: false,
+    },
   ],
 }

--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -2,7 +2,6 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 orgs.newOrg('eclipse-kuksa') {
   settings+: {
-    default_repository_permission: "none",
     description: "",
     name: "Eclipse Kuksa",
     packages_containers_internal: false,
@@ -20,6 +19,9 @@ orgs.newOrg('eclipse-kuksa') {
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
     },
     orgs.newRepo('kuksa-android-sdk') {
       allow_merge_commit: true,
@@ -28,6 +30,9 @@ orgs.newOrg('eclipse-kuksa') {
       allow_update_branch: false,
       dependabot_security_updates_enabled: true,
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           dismisses_stale_reviews: true,
@@ -43,6 +48,9 @@ orgs.newOrg('eclipse-kuksa') {
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
     },
     orgs.newRepo('kuksa-hardware') {
       allow_merge_commit: true,
@@ -52,6 +60,9 @@ orgs.newOrg('eclipse-kuksa') {
       secret_scanning: "disabled",
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
@@ -67,6 +78,9 @@ orgs.newOrg('eclipse-kuksa') {
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
     },
     orgs.newRepo('kuksa-website') {
       allow_merge_commit: true,
@@ -79,6 +93,9 @@ orgs.newOrg('eclipse-kuksa') {
       gh_pages_source_branch: "website",
       gh_pages_source_path: "/",
       web_commit_signoff_required: false,
+      workflows+: {
+        actions_can_approve_pull_request_reviews: false,
+      },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,

--- a/otterdog/eclipse-kuksa.jsonnet
+++ b/otterdog/eclipse-kuksa.jsonnet
@@ -1,5 +1,20 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
+# Default branch protection rule for KUKSA repositories
+# As a general rule all repos shall have branch protection for main but not necessarily from start.
+# It may for example be relevant to not have branch protection during the migration phase from old
+# eclipse/kuksa.* repos to repos in this orga, to be able to "redo" the migration if needed
+# Repositories may use other branch protection rules if considered needed
+
+local kuksa_default_branch_protection_rule(pattern) =
+  orgs.newBranchProtectionRule(pattern) {
+        dismisses_stale_reviews: true,
+        require_last_push_approval: true,
+        required_approving_review_count: 1,
+        requires_strict_status_checks: true,
+  };
+
+
 orgs.newOrg('eclipse-kuksa') {
   settings+: {
     description: "",
@@ -22,6 +37,9 @@ orgs.newOrg('eclipse-kuksa') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
     orgs.newRepo('kuksa-android-sdk') {
       allow_merge_commit: true,
@@ -34,12 +52,7 @@ orgs.newOrg('eclipse-kuksa') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          dismisses_stale_reviews: true,
-          require_last_push_approval: true,
-          required_approving_review_count: 1,
-          requires_strict_status_checks: true,
-        },
+        kuksa_default_branch_protection_rule('main')
       ],
     },
     orgs.newRepo('kuksa-databroker') {
@@ -64,12 +77,7 @@ orgs.newOrg('eclipse-kuksa') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 0,
-          requires_linear_history: true,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
+        kuksa_default_branch_protection_rule('main')
       ],
     },
     orgs.newRepo('kuksa-viss') {
@@ -81,6 +89,9 @@ orgs.newOrg('eclipse-kuksa') {
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },
+      branch_protection_rules: [
+        kuksa_default_branch_protection_rule('main')
+      ],
     },
     orgs.newRepo('kuksa-website') {
       allow_merge_commit: true,
@@ -97,18 +108,7 @@ orgs.newOrg('eclipse-kuksa') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 0,
-          requires_linear_history: true,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-        orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: 0,
-          requires_linear_history: true,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
+        kuksa_default_branch_protection_rule('master')
       ],
       environments: [
         orgs.newEnvironment('github-pages') {

--- a/otterdog/jsonnetfile.json
+++ b/otterdog/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": ""
         }
       },
-      "version": "v0.2.0"
+      "version": "v0.3.0"
     }
   ],
   "legacyImports": true


### PR DESCRIPTION
No branch protection from start,
will be added later migration is finished and repo content is stable

kuksa-common

Intended to contain kuksa data needed by multiple kuksa repositories. Initial ambition is to copy

https://github.com/eclipse/kuksa.val/tree/master/data/vss-core https://github.com/eclipse/kuksa.val/tree/master/jwt https://github.com/eclipse/kuksa.val/tree/master/kuksa_certificates

kuksa-python-sdk

Intended to contain the KUKSA python client & sdk, currently stored in https://github.com/eclipse/kuksa.val/tree/master/kuksa-client